### PR TITLE
fix index outside of the bounds of the array

### DIFF
--- a/Assets/Scripts/Assembly-CSharp/GameControllerScript.cs
+++ b/Assets/Scripts/Assembly-CSharp/GameControllerScript.cs
@@ -393,7 +393,7 @@ public class GameControllerScript : Singleton<GameControllerScript>
         int slotIndex = emptySlotIndex != -1 ? emptySlotIndex : this.itemSelected;
 
         this.item[slotIndex] = itemId;
-        this.itemSlot[slotIndex].texture = this.itemTextures[itemId];
+        this.itemSlot[slotIndex].texture = itemProfile.items[itemId].Icon;
 
 		InteractItem(itemProfile.items[itemId], false);
         this.UpdateItemName();


### PR DESCRIPTION
fixes the "Index was outside the bounds of the array" error that gets thrown if the player picks up a custom item. i think it caused a couple other bugs too but nothing that i've seen myself